### PR TITLE
Remove Ruby 1.9.3 from deploy-time testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ deploy:
     tags: true
     repo: sensu-plugins/sensu-plugins-apache
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Removed
+- Ruby 1.9.3 from deploy-time testing (@eheydrick)
 
 ## [1.0.0] - 2017-07-01
 #### Breaking Changes

--- a/sensu-plugins-apache.gemspec
+++ b/sensu-plugins-apache.gemspec
@@ -4,10 +4,7 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'
-
 require_relative 'lib/sensu-plugins-apache'
-
-# pvt_key = '~/.ssh/gem-private_key.pem'
 
 Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.authors                = ['Sensu-Plugins and contributors']


### PR DESCRIPTION
## Pull Request Checklist

Followup to #5.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Existing tests pass

#### Purpose

We're no longer supporting 1.9.3 so remove all testing. Also a bit of cleanup.

