### PR TITLE
[CVE-2017-8418] - updating rubocop dependency.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 #### General
 
-- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
+- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 - [ ] Update README with any necessary configuration snippets
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
 install:
 - bundle install
 rvm:
-- 2.0
 - 2.1
 - 2.2
 - 2.3.0
@@ -28,7 +27,6 @@ deploy:
     tags: true
     repo: sensu-plugins/sensu-plugins-apache
     all_branches: true
-    rvm: 2.0
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This CHANGELOG follows the format laid out [here](https://github.com/sensu-plugi
 
 ### Changed
 - updated Changelog guidelines location (@majormoses)
+- bin/metrics-apache-graphite.rb: remove magic comment for utf8 as that is the default in ruby as of ruby 2.0. See https://github.com/bbatsov/rubocop/issues/4767 for more information (@majormoses)
 
 ### Removed
 - Ruby 1.9.3 from deploy-time testing (@eheydrick)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,19 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
+This CHANGELOG follows the format laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+### Security
+- updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)
+
+### Breaking Changes
+- removed < ruby 2.1 support which was pulled as part of security updates (@majormoses)
+
+### Changed
+- updated Changelog guidelines location (@majormoses)
+
 ### Removed
 - Ruby 1.9.3 from deploy-time testing (@eheydrick)
 

--- a/bin/metrics-apache-graphite.rb
+++ b/bin/metrics-apache-graphite.rb
@@ -1,5 +1,4 @@
 #! /usr/bin/env ruby
-# encoding: UTF-8
 # frozen_string_literal: true
 
 #

--- a/sensu-plugins-apache.gemspec
+++ b/sensu-plugins-apache.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 2.0.0'
+  s.required_ruby_version  = '>= 2.1.0'
   s.summary                = 'Sensu plugins for the apache webserver'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsApache::Version::VER_STRING
@@ -37,7 +37,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 12.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.49.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
+  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
Close security vulnerability by updating rubocop dependency.

removed ruby < 2.1 support and testing:
```
Bundler could not find compatible versions for gem "ruby":
  In Gemfile:
    ruby
    bundler (~> 1.7) was resolved to 1.16.0, which depends on
      ruby (>= 1.8.7)
    pry (~> 0.10) was resolved to 0.11.3, which depends on
      ruby (>= 1.9.3)
    rubocop (~> 0.51.0) was resolved to 0.51.0, which depends on
      ruby (>= 2.1.0)
    sensu-plugins-ansible was resolved to 1.0.0, which depends on
      ruby (>= 2.0.0)
```

changelog location updates

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/77

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass



#### Purpose
Resolve CVE (see parent issue for details)
#### Known Compatibility Issues
Requires ruby 2.1 or greater